### PR TITLE
fix: Use relative API paths instead of hardcoded localhost URLs

### DIFF
--- a/frontend/src/services/tilbudService.js
+++ b/frontend/src/services/tilbudService.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:4001/api';
+const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
 
 export const tilbudService = {
   async getAllTilbud(filters = {}) {


### PR DESCRIPTION
## Bug Fix

**Issue:** #15  
**Correlation ID:** ZHC-MadMatch-20260228-013  
**Priority:** CRITICAL - CEO cannot use application

### Problem

Frontend displays "kunne ikke indlæse tilbud" error when accessed via deployed URLs (http://192.168.1.203:8080 or :8081).

### Root Cause

`tilbudService.js` uses hardcoded localhost URL as fallback:
```javascript
const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:4001/api';
```

Browsers cannot reach localhost:4001 from external access → API calls fail.

### Solution

Changed fallback to relative path:
```javascript
const API_BASE_URL = process.env.REACT_APP_API_URL || '/api';
```

Now nginx proxies `/api/*` requests to backend correctly.

### Changes

- `frontend/src/services/tilbudService.js` - 1 line changed

### Testing

- [x] Unit tests pass (103/103)
- [ ] Deploy to DEV
- [ ] **Post-deployment QA validates data loads in browser** (not just curl)
- [ ] CEO confirms fix works
- [ ] Deploy to PROD

### Risk

Low - Single line change, no logic modifications.

### Rollback

Revert commit if issues arise.

Fixes #15