### PR TITLE
feat: Danish→English translation for recipe search

### DIFF
--- a/backend/services/recipeService.test.js
+++ b/backend/services/recipeService.test.js
@@ -194,8 +194,9 @@ describe('RecipeService', () => {
       const recipes = await recipeService.fetchFromAPI('Hakket Oksekød');
       
       expect(fetch).toHaveBeenCalledTimes(1);
+      // Should translate "Hakket Oksekød" to "ground beef"
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('ingredients=hakket%20oksek%C3%B8d'),
+        expect.stringContaining('ingredients=ground%20beef'),
         expect.any(Object)
       );
       
@@ -374,8 +375,9 @@ describe('RecipeService', () => {
     it('should handle Danish meat products', async () => {
       await recipeService.getRecipes('Hakket Oksekød 8-12%');
       
+      // Should translate "Hakket Oksekød" to "ground beef"
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('hakket%20oksek%C3%B8d'),
+        expect.stringContaining('ground%20beef'),
         expect.any(Object)
       );
     });
@@ -383,8 +385,9 @@ describe('RecipeService', () => {
     it('should handle dairy products', async () => {
       await recipeService.getRecipes('Økologisk Mælk 3,5%');
       
+      // Should translate "Mælk" to "milk"
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('m%C3%A6lk'),
+        expect.stringContaining('milk'),
         expect.any(Object)
       );
     });
@@ -392,8 +395,9 @@ describe('RecipeService', () => {
     it('should handle vegetables', async () => {
       await recipeService.getRecipes('Tomater - Cherry');
       
+      // Should translate "Tomater" to "tomatoes"
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('tomater'),
+        expect.stringContaining('tomatoes'),
         expect.any(Object)
       );
     });

--- a/backend/services/translationService.js
+++ b/backend/services/translationService.js
@@ -1,0 +1,116 @@
+/**
+ * TranslationService - Simple Danish→English food translation
+ * 
+ * Purpose: Translate Danish product names to English for Spoonacular API
+ * Spoonacular only understands English ingredient names
+ * 
+ * Strategy:
+ * 1. Exact match lookup
+ * 2. Partial match for compound names (e.g. "Økologisk Hakket Oksekød")
+ * 3. Fallback to original (may be English already or brand name)
+ */
+class TranslationService {
+  constructor() {
+    // Common Danish → English food translations
+    this.foodTranslations = {
+      // Meat
+      'hakket oksekød': 'ground beef',
+      'oksekød': 'beef',
+      'svinekød': 'pork',
+      'kylling': 'chicken',
+      'kalkun': 'turkey',
+      'lam': 'lamb',
+      'bacon': 'bacon',
+      'pølser': 'sausages',
+      'pølse': 'sausage',
+      
+      // Dairy
+      'mælk': 'milk',
+      'ost': 'cheese',
+      'smør': 'butter',
+      'yoghurt': 'yogurt',
+      'fløde': 'cream',
+      'skyr': 'skyr',
+      'æg': 'eggs',
+      
+      // Vegetables
+      'kartofler': 'potatoes',
+      'kartoffel': 'potato',
+      'tomat': 'tomato',
+      'tomater': 'tomatoes',
+      'løg': 'onion',
+      'løger': 'onions',
+      'gulerødder': 'carrots',
+      'gulerod': 'carrot',
+      'salat': 'lettuce',
+      'agurk': 'cucumber',
+      'peberfrugt': 'bell pepper',
+      'peberfrugter': 'bell peppers',
+      'spinat': 'spinach',
+      'broccoli': 'broccoli',
+      'blomkål': 'cauliflower',
+      
+      // Fruits
+      'æbler': 'apples',
+      'æble': 'apple',
+      'banan': 'banana',
+      'bananer': 'bananas',
+      'appelsin': 'orange',
+      'appelsiner': 'oranges',
+      'citron': 'lemon',
+      'citroner': 'lemons',
+      'jordbær': 'strawberries',
+      
+      // Grains & Bread
+      'brød': 'bread',
+      'rugbrød': 'rye bread',
+      'pasta': 'pasta',
+      'ris': 'rice',
+      'havregryn': 'oats',
+      'mel': 'flour',
+      
+      // Common modifiers (stripped, not translated)
+      'økologisk': 'organic',
+      'frisk': 'fresh',
+      'frossen': 'frozen',
+      'dansk': 'danish',
+    };
+  }
+  
+  /**
+   * Translate Danish product name to English
+   * 
+   * @param {string} danishName - Product name in Danish
+   * @returns {string} English translation or original if no match
+   */
+  translateProductName(danishName) {
+    if (!danishName) return danishName;
+    
+    const lowerName = danishName.toLowerCase();
+    
+    // 1. Check for exact match
+    if (this.foodTranslations[lowerName]) {
+      return this.foodTranslations[lowerName];
+    }
+    
+    // 2. Check for partial matches (e.g. "Økologisk Hakket Oksekød" → "ground beef")
+    // Prioritize longer matches first (more specific)
+    // Skip common modifiers (økologisk, frisk, etc) in favor of actual food items
+    const modifiers = new Set(['økologisk', 'frisk', 'frossen', 'dansk']);
+    
+    const sortedEntries = Object.entries(this.foodTranslations)
+      .filter(([danish]) => !modifiers.has(danish))  // Prioritize food items over modifiers
+      .sort((a, b) => b[0].length - a[0].length);
+    
+    for (const [danish, english] of sortedEntries) {
+      if (lowerName.includes(danish)) {
+        return english;
+      }
+    }
+    
+    // 3. Fallback: return original (maybe it's already English or brand name)
+    return danishName;
+  }
+}
+
+module.exports = { TranslationService };

--- a/backend/services/translationService.test.js
+++ b/backend/services/translationService.test.js
@@ -1,0 +1,64 @@
+const { TranslationService } = require('./translationService');
+
+describe('TranslationService', () => {
+  let service;
+  
+  beforeEach(() => {
+    service = new TranslationService();
+  });
+  
+  describe('translateProductName', () => {
+    test('translates exact match - meat', () => {
+      expect(service.translateProductName('hakket oksekød')).toBe('ground beef');
+      expect(service.translateProductName('kylling')).toBe('chicken');
+      expect(service.translateProductName('svinekød')).toBe('pork');
+    });
+    
+    test('translates exact match - dairy', () => {
+      expect(service.translateProductName('mælk')).toBe('milk');
+      expect(service.translateProductName('ost')).toBe('cheese');
+      expect(service.translateProductName('smør')).toBe('butter');
+    });
+    
+    test('translates exact match - vegetables', () => {
+      expect(service.translateProductName('kartofler')).toBe('potatoes');
+      expect(service.translateProductName('tomat')).toBe('tomato');
+      expect(service.translateProductName('løg')).toBe('onion');
+    });
+    
+    test('translates case-insensitive', () => {
+      expect(service.translateProductName('HAKKET OKSEKØD')).toBe('ground beef');
+      expect(service.translateProductName('Mælk')).toBe('milk');
+      expect(service.translateProductName('Kylling')).toBe('chicken');
+    });
+    
+    test('translates partial match - compound names', () => {
+      expect(service.translateProductName('Økologisk Hakket Oksekød')).toBe('ground beef');
+      expect(service.translateProductName('Dansk Hakket Oksekød 8-12%')).toBe('ground beef');
+      expect(service.translateProductName('Frisk Mælk')).toBe('milk');
+    });
+    
+    test('prioritizes longer matches', () => {
+      // "hakket oksekød" should match before "oksekød"
+      expect(service.translateProductName('hakket oksekød')).toBe('ground beef');
+      expect(service.translateProductName('oksekød')).toBe('beef');
+    });
+    
+    test('returns original if no match', () => {
+      expect(service.translateProductName('Unknown Product')).toBe('Unknown Product');
+      expect(service.translateProductName('Coca Cola')).toBe('Coca Cola');
+      expect(service.translateProductName('Kims Chips')).toBe('Kims Chips');
+    });
+    
+    test('handles empty or null input', () => {
+      expect(service.translateProductName('')).toBe('');
+      expect(service.translateProductName(null)).toBe(null);
+      expect(service.translateProductName(undefined)).toBe(undefined);
+    });
+    
+    test('has at least 20 common food translations', () => {
+      const translationCount = Object.keys(service.foodTranslations).length;
+      expect(translationCount).toBeGreaterThanOrEqual(20);
+    });
+  });
+});


### PR DESCRIPTION
## Feature Enhancement

**Issue:** Spoonacular API does not understand Danish product names, returning 0 recipes

**Solution:** Add simple translation layer for common Danish food terms

**Implementation:**
- Created TranslationService with Danish→English food dictionary (30+ common items)
- Updated RecipeService to translate product names before Spoonacular API calls
- Cache keys now use English names for consistency
- Added comprehensive unit tests (9 tests, all passing)
- Updated existing integration tests to reflect translation behavior

**Testing:**
- ✅ Translation service works for common foods (meat, dairy, vegetables, fruits, grains)
- ✅ Partial matching works ("Økologisk Hakket Oksekød" → "ground beef")
- ✅ Cache consistency (Danish and English names map to same cache key)
- ✅ All 110 tests pass

**Example:**
- Before: "Hakket oksekød" → sent as Danish → 0 recipes ❌
- After: "Hakket oksekød" → translated to "ground beef" → multiple recipes ✅

**Files Changed:**
- `backend/services/translationService.js` (new)
- `backend/services/translationService.test.js` (new)
- `backend/services/recipeService.js` (updated to use translation)
- `backend/services/recipeService.test.js` (updated assertions)

Correlation-ID: ZHC-MadMatch-20260228-016